### PR TITLE
Fix Cosmos bootstrap so the sample deploys on Azure App Service Linux

### DIFF
--- a/BlogFunctionApp/Program.cs
+++ b/BlogFunctionApp/Program.cs
@@ -20,8 +20,11 @@ string connString = builder.Configuration["CosmosDbBlogConnectionString"]
 var clientBuilder = new CosmosClientBuilder(connString);
 CosmosClient client = clientBuilder
     .WithApplicationName(databaseName)
-    .WithApplicationName(Regions.EastUS)
-    .WithConnectionModeDirect()
+    // Gateway mode (HTTPS 443 only) for the same App Service / Functions Linux
+    // outbound-port reason as BlogWebApp. If you deploy this change-feed worker
+    // to a Linux plan, direct mode's 10000-20000 TCP range may be unavailable.
+    // Drop this hunk if you prefer direct mode for the change-feed worker.
+    .WithConnectionModeGateway()
     .WithSerializerOptions(new CosmosSerializationOptions { PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase })
     .Build();
 

--- a/BlogWebApp/BlogWebApp.csproj
+++ b/BlogWebApp/BlogWebApp.csproj
@@ -11,6 +11,21 @@
     <Folder Include="wwwroot\" />
   </ItemGroup>
 
+  <!-- Cosmos sproc/trigger scripts are read from disk at startup
+       (Program.cs InitializeCosmosBlogClientInstanceAsync). They live outside
+       wwwroot, so the web SDK treats them as non-copied None items by default
+       and they are absent from the published app, so the startup bootstrap
+       throws FileNotFoundException on App Service. Move them to Content with
+       copy-to-output + copy-to-publish. The None Remove first pulls them out of
+       the default None glob to avoid a same-path-in-two-item-types conflict. -->
+  <ItemGroup>
+    <None Remove="CosmosDbScripts\**\*.js" />
+    <Content Include="CosmosDbScripts\**\*.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.7" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />

--- a/BlogWebApp/Program.cs
+++ b/BlogWebApp/Program.cs
@@ -70,8 +70,13 @@ static async Task<BlogCosmosDbService> InitializeCosmosBlogClientInstanceAsync(I
     var clientBuilder = new CosmosClientBuilder(account, key);
     CosmosClient client = clientBuilder
         .WithApplicationName(databaseName)
-        .WithApplicationName(Regions.EastUS)
-        .WithConnectionModeDirect()
+        // Gateway mode (HTTPS 443 only). Direct mode needs outbound TCP on the
+        // 10000-20000 port range, which Azure App Service Linux does not reliably
+        // allow: control-plane ops (create database/containers) route through the
+        // gateway and succeed, but data-plane ops (sproc upserts, queries) hang
+        // under direct mode and trip the App Service container-start timeout.
+        // Gateway is the App Service-recommended mode and is fine for this sample.
+        .WithConnectionModeGateway()
         .WithSerializerOptions(new CosmosSerializationOptions { PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase })
         .Build();
 
@@ -101,16 +106,21 @@ static async Task<BlogCosmosDbService> InitializeCosmosBlogClientInstanceAsync(I
     // Posts get upserted into the Feed container from the change feed.
     await database.Database.CreateContainerIfNotExistsAsync("Feed", "/type");
 
-    // Upsert the sprocs in the posts container.
+    // Upsert the sprocs in the posts container. Paths are built with
+    // Path.Combine off AppContext.BaseDirectory so they resolve on Linux
+    // (App Service) as well as Windows, and regardless of the process working
+    // directory. Hardcoded backslash literals broke on Linux, where the
+    // backslash is a literal filename character, not a path separator.
+    var scriptsRoot = Path.Combine(AppContext.BaseDirectory, "CosmosDbScripts");
     var postsContainer = database.Database.GetContainer("Posts");
-    await UpsertStoredProcedureAsync(postsContainer, @"CosmosDbScripts\sprocs\createComment.js");
-    await UpsertStoredProcedureAsync(postsContainer, @"CosmosDbScripts\sprocs\createLike.js");
-    await UpsertStoredProcedureAsync(postsContainer, @"CosmosDbScripts\sprocs\deleteLike.js");
-    await UpsertStoredProcedureAsync(postsContainer, @"CosmosDbScripts\sprocs\updateUsernames.js");
+    await UpsertStoredProcedureAsync(postsContainer, Path.Combine(scriptsRoot, "sprocs", "createComment.js"));
+    await UpsertStoredProcedureAsync(postsContainer, Path.Combine(scriptsRoot, "sprocs", "createLike.js"));
+    await UpsertStoredProcedureAsync(postsContainer, Path.Combine(scriptsRoot, "sprocs", "deleteLike.js"));
+    await UpsertStoredProcedureAsync(postsContainer, Path.Combine(scriptsRoot, "sprocs", "updateUsernames.js"));
 
     // Add the feed container post-trigger (truncates the Feed container).
     var feedContainer = database.Database.GetContainer("Feed");
-    await UpsertTriggerAsync(feedContainer, @"CosmosDbScripts\triggers\truncateFeed.js", TriggerOperation.All, TriggerType.Post);
+    await UpsertTriggerAsync(feedContainer, Path.Combine(scriptsRoot, "triggers", "truncateFeed.js"), TriggerOperation.All, TriggerType.Post);
 
     // Seed a Hello World post on first run so the home page is never empty.
     if (insertHelloWorldPost)


### PR DESCRIPTION
## Summary

The sample has only ever been run via `dotnet run` on Windows (or against the Cosmos emulator), so three latent bugs in the Cosmos startup bootstrap surfaced the first time it was deployed to **Azure App Service Linux**. Symptom: the app crash-loops on startup — the database and containers get created, but no Hello-World seed runs, and the container hits the App Service start timeout (HTTP 500 / "container did not start within the time limit").

All three are Linux/publish-only; none can reproduce on a local Windows `dotnet run`.

## The three fixes

1. **Sproc/trigger scripts weren't published.** `CosmosDbScripts/*.js` live outside `wwwroot`, so the web SDK treats them as non-copied `None` items — they're absent from the published app, and `File.ReadAllTextAsync` throws `FileNotFoundException`. `BlogWebApp.csproj` now moves them to `Content` with `CopyToOutputDirectory` + `CopyToPublishDirectory`. **Verified** all five scripts land under `CosmosDbScripts/` in `dotnet publish` output.

2. **Backslash paths.** `@"CosmosDbScripts\sprocs\createComment.js"` — on Linux the backslash is a literal filename character, not a separator. Switched to `Path.Combine(AppContext.BaseDirectory, "CosmosDbScripts", ...)`, which resolves on both OSes and regardless of working directory.

3. **Direct connection mode.** `WithConnectionModeDirect()` needs outbound TCP on the 10000–20000 range, which App Service Linux doesn't reliably allow. Control-plane ops (create database/containers) route through the gateway and succeed — which is why containers appear — but data-plane ops (sproc upserts, queries) hang and trip the container-start timeout. Switched to `WithConnectionModeGateway()` (HTTPS 443), the App Service-recommended mode. Also dropped an erroneous second `WithApplicationName(Regions.EastUS)` that clobbered the app-name telemetry string.

## Scope note

The connection-mode fix (#3) is also applied to **BlogFunctionApp** for the same reason — if the change-feed worker is deployed to a Linux Functions plan, it hits the identical outbound-port issue. That hunk is cleanly separable; drop it if you'd prefer to keep Direct mode in the change-feed worker for the throughput story the sample teaches. The web-app fixes (#1, #2, #3-web) are the launch-blockers.

## Test plan

- [x] `dotnet publish BlogWebApp -c Release` succeeds and emits all 5 `CosmosDbScripts/*.js` into the output (the fix for #1, verified)
- [x] `dotnet build BlogFunctionApp` — 0 errors
- [ ] Deploy `BlogWebApp` to an App Service Linux instance, confirm first-run bootstrap creates the database + containers + sprocs + Hello-World seed without crash-looping (verified out-of-band on a downstream fork that carries the same bootstrap; reproduce here if desired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)